### PR TITLE
Fix importing ICC profiles, and declare DPI awareness

### DIFF
--- a/iccprof.cpp
+++ b/iccprof.cpp
@@ -68,7 +68,7 @@ int ImportICCProfileByFilename(Png *png, const TCHAR *fn)
 		goto done;
 	}
 
-	unc_prof_len=GetFileSize(fh,NULL)-4;
+	unc_prof_len=GetFileSize(fh,NULL);
 	if(unc_prof_len<128 || unc_prof_len>100000000) goto done;
 	unc_prof_data = (unsigned char*)malloc(unc_prof_len);
 	if(!unc_prof_data) goto done;

--- a/tweakpng.manifest
+++ b/tweakpng.manifest
@@ -21,4 +21,9 @@
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
     </application>
   </compatibility>
+  <asmv3:application xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+    <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+      <dpiAwareness>PerMonitor</dpiAwareness>
+    </asmv3:windowsSettings>
+  </asmv3:application>
 </assembly>


### PR DESCRIPTION
# ICC Profiles & DPI Awareness

Howdy!
This PR has two changes:

- ICC profiles were previously corrupted on import, as they had their last 4 bytes cut off, so this fixes that
- A section was added to the assembly manifest that declares the application as DPI-aware, so that Windows doesn't make the UI blurry on high-DPI monitors
  - This could previously be worked around with Windows' high DPI scaling override settings, but that didn't seem to work for me  with the latest version (maybe just because it has a manifest now, since bad47f8b516242a5c02d0dbd8e54dcefc2e3a70c)

Thank you for making this application, by the way! I have found it very helpful for a long time.